### PR TITLE
Made spaceplane passenger cabins require training

### DIFF
--- a/GameData/RP-0/CrewTrainingTimes.cfg
+++ b/GameData/RP-0/CrewTrainingTimes.cfg
@@ -73,7 +73,7 @@ TRAININGTIMES
 	ProtoSpaceplane = 100, EVA, Docking // a bit more than SecondGenCapsule because it needs actual piloting
 		RO-Mk1Cockpit = ProtoSpaceplane
 		RO-Mk1CockpitInline = ProtoSpaceplane
-		RO-MK1CrewModule = ProtoSpaceplane
+		RO-Mk1CrewModule = ProtoSpaceplane
 		MK1CrewCabin = ProtoSpaceplane
 	ProtoSpaceplane-Mission = 120
 

--- a/GameData/RP-0/CrewTrainingTimes.cfg
+++ b/GameData/RP-0/CrewTrainingTimes.cfg
@@ -82,6 +82,7 @@ TRAININGTIMES
 		mk2Cockpit-Standard = Spaceplane
 		mk2CrewCabin = Spaceplane
 		mk3Cockpit-Shuttle = Spaceplane
+		mk3CrewCabin = Spaceplane
 	Spaceplane-Mission = 150
 	
 //**********************************************************************************

--- a/GameData/RP-0/CrewTrainingTimes.cfg
+++ b/GameData/RP-0/CrewTrainingTimes.cfg
@@ -59,6 +59,7 @@ TRAININGTIMES
 	X-15 = 100, Suborbital, XPlane
 		Mark1Cockpit = X-15
 		Mark2Cockpit = X-15
+		KerbCan = X-15
 	X-15-Mission = 15
 	
 	// Jet Fighters
@@ -72,12 +73,15 @@ TRAININGTIMES
 	ProtoSpaceplane = 100, EVA, Docking // a bit more than SecondGenCapsule because it needs actual piloting
 		RO-Mk1Cockpit = ProtoSpaceplane
 		RO-Mk1CockpitInline = ProtoSpaceplane
+		RO-MK1CrewModule = ProtoSpaceplane
+		MK1CrewCabin = ProtoSpaceplane
 	ProtoSpaceplane-Mission = 120
 
 	Spaceplane = 25, ProtoSpaceplane
-		mk2Cockpit.Inline = Spaceplane
-		mk2Cockpit.Standard = Spaceplane
-		mk3Cockpit.Shuttle = Spaceplane
+		mk2Cockpit-Inline = Spaceplane
+		mk2Cockpit-Standard = Spaceplane
+		mk2CrewCabin = Spaceplane
+		mk3Cockpit-Shuttle = Spaceplane
 	Spaceplane-Mission = 150
 	
 //**********************************************************************************


### PR DESCRIPTION
They used to default to 0 training time, not the desired behavior. Using this solution you'll have to train "mission specialists" or "tourists" for your spaceplane flights the same amount as actual pilots, which is perhaps not ideal. At the same time, you'll probably be bulk training all the crew to go on a mission anyways so any discrepancy in crew training time would just be annoying in the long run.